### PR TITLE
Separate density from height

### DIFF
--- a/nougat.tcl
+++ b/nougat.tcl
@@ -194,7 +194,7 @@ proc run_nougat {system config_dict bindims polar quantity_of_interest foldernam
 
             ;# Make necessary calculations (if any), then bin and average them
             if {$quantity_of_interest eq "height"} {
-                set outfiles [averageHeightAndDensity $res_dict $outfiles [dict get $sel_info lipid_list] [dict get $sel_info zvals_list]]
+                set outfiles [averageHeight $res_dict $outfiles [dict get $sel_info lipid_list] [dict get $sel_info zvals_list]]
             } elseif {$quantity_of_interest eq "tilt_order"} {
                 set tilts [fitVecsToSel [dict keys $selections] [dict get $sel_info xvals_list] [dict get $sel_info yvals_list] [dict get $sel_info zvals_list]]
                 set orders [calculateOrderParameters [dict keys $selections] [dict get $sel_info xvals_list] [dict get $sel_info yvals_list] [dict get $sel_info zvals_list]]

--- a/nougat.tcl
+++ b/nougat.tcl
@@ -203,8 +203,11 @@ proc run_nougat {system config_dict bindims polar quantity_of_interest foldernam
 
             ;# Now that all information has been binned, print it to files
             dict for {key val} [dict get $outfiles $selex] {
+                if {[string match "counts*" $key]} {
+                    continue
+                }
                 printFrame [dict get $bindims N1] $outfiles $key [dict get $bindims d1] [dict get $config_dict min] [dict get $bindims N2] $polar $selex
-
+                
                 ;# cleanup before next step
                 set outfiles [dict unset outfiles $selex $key bin]
             } 

--- a/nougat.tcl
+++ b/nougat.tcl
@@ -135,8 +135,8 @@ proc start_nougat {system config_path dr_N1 N2 start end step polar} {
     ;# run nougat twice, once to compute height and density and once to compute
     ;# lipid tail vectors and order parameters
     
-    run_nougat $system $config_dict $bindims $polar "height_density" $foldername
-    run_nougat $system $config_dict $bindims $polar "tilt_order" $foldername
+    run_nougat $system $config_dict $bindims $polar "height" $foldername
+    #run_nougat $system $config_dict $bindims $polar "tilt_order" $foldername
 
 }
 
@@ -193,7 +193,7 @@ proc run_nougat {system config_dict bindims polar quantity_of_interest foldernam
             set res_dict [createResidueDictionaries [dict get $config_dict species] [dict get $config_dict headnames] [dict get $sel_info lipid_list] [dict get $sel_info name_list] $dim1_bins_list $dim2_bins_list [dict get $sel_info leaflet_list] $selex]
 
             ;# Make necessary calculations (if any), then bin and average them
-            if {$quantity_of_interest eq "height_density"} {
+            if {$quantity_of_interest eq "height"} {
                 set outfiles [averageHeightAndDensity $res_dict $outfiles [dict get $sel_info lipid_list] [dict get $sel_info zvals_list]]
             } elseif {$quantity_of_interest eq "tilt_order"} {
                 set tilts [fitVecsToSel [dict keys $selections] [dict get $sel_info xvals_list] [dict get $sel_info yvals_list] [dict get $sel_info zvals_list]]
@@ -216,7 +216,7 @@ proc run_nougat {system config_dict bindims polar quantity_of_interest foldernam
     }
 
     ;# output log info that nougat.py can read later 
-    if {$quantity_of_interest eq "height_density"} {
+    if {$quantity_of_interest eq "height"} {
         outputNougatLog [dict get $config_dict start] [dict get $config_dict nframes] [dict get $config_dict step] [dict get $config_dict species] [dict get $config_dict acyl_names] $system [dict get $config_dict headnames] $coordsys $foldername [dict get $bindims N1] [dict get $bindims N2] [dict get $bindims d1] [dict get $bindims d2]
         
         ;# this will only work if your TMD helices are set to occupancy 1

--- a/plotting/nougat.py
+++ b/plotting/nougat.py
@@ -56,11 +56,11 @@ def run_nougat(polar, inclusion_drawn):
 
     # $$$$$$$$$$ UNTESTED FEATURES BELOW $$$$$$$$$$$
 
-    save_areas(system_dict["bin_info"], 0, polar)
+    # save_areas(system_dict["bin_info"], 0, polar)
 
-    calculate_density(polar, system_dict, cwd)
+    # calculate_density(polar, system_dict, cwd)
 
-    calculate_order(polar, system_dict, cwd)
+    # calculate_order(polar, system_dict, cwd)
 
     # calculate_tilt(sys_name, system_dict, coordsys, inclusion, cwd)
 

--- a/plotting/utils.py
+++ b/plotting/utils.py
@@ -461,6 +461,7 @@ def plot_all_quantities(polar, system_dict, cwd, inclusion):
             fig, ax = plot_maker(hmap_dims, hmap_data, inclusion, "thickness", polar)
             plt.savefig(cwd.joinpath("figures", "thickness", field + ".pdf"))
             plt.close()
+        """
         for field in ["zone", "ztwo"]:
             hmap_data = np.genfromtxt(cwd.joinpath("average", "density", species, field + ".dat"), delimiter=",")
             fig, ax = plot_maker(hmap_dims, hmap_data, inclusion, "density", polar)
@@ -471,6 +472,7 @@ def plot_all_quantities(polar, system_dict, cwd, inclusion):
                 fig, ax = plot_maker(hmap_dims, hmap_data, inclusion, "order", polar)
                 plt.savefig(cwd.joinpath("figures", "order", species, "tail" + str(tail), field + ".pdf"))
                 plt.close()
+        """
 
 
 def plot_maker(dims, data, protein, quant, polar):

--- a/test/unit_test.test
+++ b/test/unit_test.test
@@ -808,17 +808,17 @@ test Avgheight {
     mol delete top
 }
 
-test Avgtiltord {
-    Test: averageTiltAndOrderParameter
-} -setup {
-    set fp [open "PO_cart_12_12_0_1_1/tcl_output/tilt/POPC/tail0/ztwo.dat" r]
-    set filedata [read $fp]
-    set fp2 [open "PO_cart_12_12_0_1_1/tcl_output/order/POPC/tail1/zone.dat" r]
-    set filedata2 [read $fp2]
-    set match [list [format "%.3f" [lindex $filedata 2 0]] [format "%.3f" [lindex $filedata2 2 0]]]
-} -body {
-    return $match
-} -result {0.104 0.317} -cleanup {
-    mol delete top
-    exec rm -r PO_cart_12_12_0_1_1
-}
+#test Avgtiltord {
+#    Test: averageTiltAndOrderParameter
+#} -setup {
+#    set fp [open "PO_cart_12_12_0_1_1/tcl_output/tilt/POPC/tail0/ztwo.dat" r]
+#    set filedata [read $fp]
+#    set fp2 [open "PO_cart_12_12_0_1_1/tcl_output/order/POPC/tail1/zone.dat" r]
+#    set filedata2 [read $fp2]
+#    set match [list [format "%.3f" [lindex $filedata 2 0]] [format "%.3f" [lindex $filedata2 2 0]]]
+#} -body {
+#    return $match
+#} -result {0.104 0.317} -cleanup {
+#    mol delete top
+#    exec rm -r PO_cart_12_12_0_1_1
+#}

--- a/test/unit_test.test
+++ b/test/unit_test.test
@@ -793,20 +793,18 @@ test Normalizationdensitytest {
     mol delete top
 }
 
-test Avgheightdensity {
-    Test: averageHeightAndDensity
+test Avgheight {
+    Test: averageHeight
 } -setup {
     mol new ../testing_materials/GNP_trajectory/em.gro
     mol addfile ../testing_materials/GNP_trajectory/test.xtc waitfor all
     start_nougat PO nougat_config.txt 12 12 0 1 1 0
     set fp [open "PO_cart_12_12_0_1_1/tcl_output/height/zone.dat" r]
     set filedata [read $fp]
-    set fp2 [open "PO_cart_12_12_0_1_1/tcl_output/density/POPC/zone.dat" r]
-    set filedata2 [read $fp2]
-    set match [list [format "%.2f" [lindex $filedata 2 0]] [format "%.2f" [lindex $filedata2 2 0]]]
+    set match [format "%.2f" [lindex $filedata 2 0]]
 } -body {
     return $match
-} -result {12.49 5.00} -cleanup {
+} -result 12.49 -cleanup {
     mol delete top
 }
 

--- a/test/unit_test.test
+++ b/test/unit_test.test
@@ -699,7 +699,7 @@ test createatomselects {
 } -setup {
     mol new ../testing_materials/lipid_membrane/insane2.gro
     set config_dict [cell_prep "nougat_config.txt" 1]
-    set selly [createAtomSelections "height_density" $config_dict]
+    set selly [createAtomSelections "height" $config_dict]
     set sel [atomselect top "resname POPC and not name NC3 PO4 GL1 GL2"]
     set lipnum [llength [$sel get resid]]
     set cselnum [llength [[dict get $selly z1z2] get resid]]

--- a/test/unit_test.test
+++ b/test/unit_test.test
@@ -808,17 +808,17 @@ test Avgheight {
     mol delete top
 }
 
-#test Avgtiltord {
-#    Test: averageTiltAndOrderParameter
-#} -setup {
-#    set fp [open "PO_cart_12_12_0_1_1/tcl_output/tilt/POPC/tail0/ztwo.dat" r]
-#    set filedata [read $fp]
-#    set fp2 [open "PO_cart_12_12_0_1_1/tcl_output/order/POPC/tail1/zone.dat" r]
-#    set filedata2 [read $fp2]
-#    set match [list [format "%.3f" [lindex $filedata 2 0]] [format "%.3f" [lindex $filedata2 2 0]]]
-#} -body {
-#    return $match
-#} -result {0.104 0.317} -cleanup {
-#    mol delete top
-#    exec rm -r PO_cart_12_12_0_1_1
-#}
+test Avgtiltord {
+    Test: averageTiltAndOrderParameter
+} -setup {
+    set fp [open "PO_cart_12_12_0_1_1/tcl_output/tilt/POPC/tail0/ztwo.dat" r]
+    set filedata [read $fp]
+    set fp2 [open "PO_cart_12_12_0_1_1/tcl_output/order/POPC/tail1/zone.dat" r]
+    set filedata2 [read $fp2]
+    set match [list [format "%.3f" [lindex $filedata 2 0]] [format "%.3f" [lindex $filedata2 2 0]]]
+} -body {
+    return $match
+} -result {0.104 0.317} -cleanup {
+    mol delete top
+    exec rm -r PO_cart_12_12_0_1_1
+}

--- a/test/unit_test.test
+++ b/test/unit_test.test
@@ -808,6 +808,9 @@ test Avgheight {
     mol delete top
 }
 
+
+# THESE TESTS WILL FAIL INTENTIONALLY: THESE FEATURES HAVE NOT BEEN FULLY IMPLEMENTED
+
 test Avgtiltord {
     Test: averageTiltAndOrderParameter
 } -setup {
@@ -821,4 +824,19 @@ test Avgtiltord {
 } -result {0.104 0.317} -cleanup {
     mol delete top
     exec rm -r PO_cart_12_12_0_1_1
+}
+
+test Avgdensity {
+    Test: averageDensity
+} -setup {
+    mol new ../testing_materials/GNP_trajectory/em.gro
+    mol addfile ../testing_materials/GNP_trajectory/test.xtc waitfor all
+    start_nougat PO nougat_config.txt 12 12 0 1 1 0
+    set fp [open "PO_cart_12_12_0_1_1/tcl_output/density/POPC/zone.dat" r]
+    set filedata [read $fp]
+    set match [format "%.2f" [lindex $filedata 2 0]]
+} -body {
+    return $match
+} -result 12.49 -cleanup {
+    mol delete top
 }

--- a/test/unit_test.test
+++ b/test/unit_test.test
@@ -612,22 +612,18 @@ test Mixmemjoiningnames {
 mol delete top
 }
 
-test checkheightdensityfilescreated {
+test checkheightfilescreated {
     Test: createOutfiles
 } -setup {
-    set outfiles [createOutfiles height_density "POPC DTPC" "I DONT MATTER" "t1"]
+    set outfiles [createOutfiles height "POPC DTPC" "I DONT MATTER" "t1"]
     foreach channel [file channels "file*"] {
         close $channel
     }
     set heightfiles [ glob -nocomplain t1/tcl_output/height/* ]
     set filelength [llength $heightfiles]
-    foreach folder "POPC DTPC combined" {
-        set densityfiles [ glob -nocomplain t1/tcl_output/density/$folder/* ]
-        set filelength [expr $filelength + [llength $densityfiles]]
-    }
 } -body {
     return $filelength
-} -result 12 -cleanup {
+} -result 3 -cleanup {
     exec rm -r t1
 }
 

--- a/testing_materials/tests/test_nougat_outputs.py
+++ b/testing_materials/tests/test_nougat_outputs.py
@@ -271,6 +271,7 @@ def test_if_thicknesses_match(cwd, coordsys, surface2, system):
     assert arrays_equal(paths, 'npy', 1e-11)
 
 
+"""
 def test_if_densities_match(cwd, coordsys, surface2):
     if coordsys == "cart":
         coordsys_path = "_cart_5_5_0_-1_1"
@@ -280,6 +281,7 @@ def test_if_densities_match(cwd, coordsys, surface2):
     test = cwd.joinpath("E-protein_trajectory/test" + coordsys_path, "trajectory", "density", "DTPC", surface2 + ".npy")
     paths = Comparison(test, exp)
     assert arrays_equal(paths, 'npy', 1e-11)
+"""
 
 
 @pytest.mark.xfail(strict=True)
@@ -318,8 +320,9 @@ def test_if_avg_heights_and_curvatures_match(cwd, coordsys, surface4, system, av
     assert arrays_equal(paths, 'dat', 1e-11)
 
 
+"""
 def test_if_avg_densities_match(cwd, coordsys, surface2, system):
     paths = make_avg_paths(cwd, system, coordsys, surface2, "avgdensity")
     assert arrays_equal(paths, 'dat', 1e-11)
-
+"""
 # Still needed: thickness, order, tilt

--- a/testing_materials/tests/test_nougat_outputs.py
+++ b/testing_materials/tests/test_nougat_outputs.py
@@ -310,6 +310,17 @@ def test_whether_flat(cwd, coordsys):
     assert avgHplus <= 0.000000000001 and avgHplus >= -0.000000000001
 
 
+def test_whether_flat_gaussian(cwd, coordsys):
+    if coordsys == "cart":
+        settings = "_5_5_0_-1_1"
+    else:
+        settings = "_3_12_0_-1_1"
+    Kone = np.load(cwd.joinpath("flat_surface_test", "test_" + coordsys + settings, "trajectory", "curvature", "gaussian", "zone.npy"))
+    Ktwo = np.load(cwd.joinpath("flat_surface_test", "test_" + coordsys + settings, "trajectory", "curvature", "gaussian", "ztwo.npy"))
+    Kplus = Kone + Ktwo / 2.0
+    avgKplus = np.nanmean(Kplus)
+    assert avgKplus <= 0.000000000001 and avgKplus >= -0.000000000001
+
 # Still needed: order, tilt
 
 # Test if time-averages match

--- a/testing_materials/tests/test_nougat_outputs.py
+++ b/testing_materials/tests/test_nougat_outputs.py
@@ -207,7 +207,7 @@ def test_if_tcl_heights_match(cwd, coordsys, surface2, system):
 # Still needed: density, order, tilt tests
 
 
-# Test if npy outputs match
+# Test if python trajectory outputs match
 
 def test_if_heights_and_curvatures_match(cwd, coordsys, surface4, quantity, system):
     paths = make_py_paths(cwd, system, coordsys, surface4, quantity, "npy")
@@ -217,33 +217,6 @@ def test_if_heights_and_curvatures_match(cwd, coordsys, surface4, quantity, syst
 def test_if_thicknesses_match(cwd, coordsys, surface2, system):
     paths = make_py_paths(cwd, system, coordsys, surface2, "thickness", "npy")
     assert arrays_equal(paths, 'npy', 1e-11)
-
-
-"""
-def test_if_densities_match(cwd, coordsys, surface2):
-    if coordsys == "cart":
-        coordsys_path = "_cart_5_5_0_-1_1"
-    elif coordsys == "polar":
-        coordsys_path = "_polar_3_12_0_-1_1"
-    exp = cwd.joinpath("E-protein_trajectory/E-protein" + coordsys_path, "trajectory", "density", "DTPC", surface2 + ".npy")
-    test = cwd.joinpath("E-protein_trajectory/test" + coordsys_path, "trajectory", "density", "DTPC", surface2 + ".npy")
-    paths = Comparison(test, exp)
-    assert arrays_equal(paths, 'npy', 1e-11)
-"""
-
-
-@pytest.mark.xfail(strict=True)
-def test_if_leaflets_are_distinct(cwd, coordsys, quantity, system):
-    zone_test, _ = make_py_paths(cwd, system, coordsys, "zone", quantity, "npy")
-    ztwo_test, _ = make_py_paths(cwd, system, coordsys, "ztwo", quantity, "npy")
-    assert arrays_equal((zone_test, ztwo_test), 'npy', 0)
-
-
-@pytest.mark.xfail(strict=True)
-def test_if_leaflet_thicknesses_are_distinct(cwd, coordsys, system):
-    zone_test, _ = make_py_paths(cwd, system, coordsys, "zone", "thickness", "npy")
-    ztwo_test, _ = make_py_paths(cwd, system, coordsys, "ztwo", "thickness", "npy")
-    assert arrays_equal((zone_test, ztwo_test), 'npy', 0)
 
 
 def test_whether_flat(cwd, coordsys):
@@ -269,10 +242,24 @@ def test_whether_flat_gaussian(cwd, coordsys):
     avgKplus = np.nanmean(Kplus)
     assert avgKplus <= 0.000000000001 and avgKplus >= -0.000000000001
 
+
+@pytest.mark.xfail(strict=True)
+def test_if_leaflets_are_distinct(cwd, coordsys, quantity, system):
+    zone_test, _ = make_py_paths(cwd, system, coordsys, "zone", quantity, "npy")
+    ztwo_test, _ = make_py_paths(cwd, system, coordsys, "ztwo", quantity, "npy")
+    assert arrays_equal((zone_test, ztwo_test), 'npy', 0)
+
+
+@pytest.mark.xfail(strict=True)
+def test_if_leaflet_thicknesses_are_distinct(cwd, coordsys, system):
+    zone_test, _ = make_py_paths(cwd, system, coordsys, "zone", "thickness", "npy")
+    ztwo_test, _ = make_py_paths(cwd, system, coordsys, "ztwo", "thickness", "npy")
+    assert arrays_equal((zone_test, ztwo_test), 'npy', 0)
+
 # Still needed: order, tilt
 
-# Test if time-averages match
 
+# Test if python time-averages match
 
 def test_if_avg_heights_and_curvatures_match(cwd, coordsys, surface4, quantity, system):
     if quantity != "normal_vectors":
@@ -282,9 +269,22 @@ def test_if_avg_heights_and_curvatures_match(cwd, coordsys, surface4, quantity, 
         assert True
 
 
+# Still needed: thickness, order, tilt
+
+# BELOW: old density tests that need to be re-implemented
 """
+def test_if_densities_match(cwd, coordsys, surface2):
+    if coordsys == "cart":
+        coordsys_path = "_cart_5_5_0_-1_1"
+    elif coordsys == "polar":
+        coordsys_path = "_polar_3_12_0_-1_1"
+    exp = cwd.joinpath("E-protein_trajectory/E-protein" + coordsys_path, "trajectory", "density", "DTPC", surface2 + ".npy")
+    test = cwd.joinpath("E-protein_trajectory/test" + coordsys_path, "trajectory", "density", "DTPC", surface2 + ".npy")
+    paths = Comparison(test, exp)
+    assert arrays_equal(paths, 'npy', 1e-11)
+
+
 def test_if_avg_densities_match(cwd, coordsys, surface2, system):
     paths = make_avg_paths(cwd, system, coordsys, surface2, "avgdensity")
     assert arrays_equal(paths, 'dat', 1e-11)
 """
-# Still needed: thickness, order, tilt

--- a/testing_materials/tests/test_nougat_outputs.py
+++ b/testing_materials/tests/test_nougat_outputs.py
@@ -266,10 +266,10 @@ def test_if_avg_heights_and_curvatures_match(cwd, coordsys, surface4, quantity, 
         paths = make_py_paths(cwd, system, coordsys, surface4, quantity, "dat")
         assert arrays_equal(paths, 'dat', 1e-11)
     else:
-        assert True
+        return
 
+# Still needed: thickness, order, tilt, normal_vectors
 
-# Still needed: thickness, order, tilt
 
 # BELOW: old density tests that need to be re-implemented
 """

--- a/testing_materials/tests/test_nougat_outputs.py
+++ b/testing_materials/tests/test_nougat_outputs.py
@@ -167,7 +167,7 @@ def arrays_equal(paths, filetype, tolerance):
 
     Parameters
     ----------
-    paths: named tuple
+    paths: Comparison named tuple
         Named tuple of two path objects.
     filetype: string
         The filetype of f1 and f2

--- a/utilities/helper_procs.tcl
+++ b/utilities/helper_procs.tcl
@@ -359,7 +359,6 @@ proc printValue {file value endLine} {
 #       - min needs to be implemented 
 
 proc printFrame {N1 outfiles key d1 min N2 polar selex} {
-
     set file [dict get $outfiles $selex $key fname]
 
     ;# starts new line in outfile with bin values

--- a/utilities/helper_procs.tcl
+++ b/utilities/helper_procs.tcl
@@ -1169,7 +1169,7 @@ proc averageTiltAndOrderParameter {residueDictionary outfiles lipidList tilts or
     return $outfiles
 }
 
-# averageHeightAndDensity (Previously: height_density_averaging)
+# averageHeight (Previously: height_density_averaging)
 #
 #       uses residueDictionary entries to compute bin averages, then assigns them to the correct outfile
 #
@@ -1184,7 +1184,7 @@ proc averageTiltAndOrderParameter {residueDictionary outfiles lipidList tilts or
 #       Returns dictionary with average height, density and counts 
 #       of lipids for a specific bin 
 
-proc averageHeightAndDensity {residueDictonary outfiles lipidList zValsList} {
+proc averageHeight {residueDictonary outfiles lipidList zValsList} {
     dict for {bin indices} $residueDictonary {
         set leaf [string range $bin end end]
         set correct_bin [string range $bin 0 [expr {[string length $bin] - 3}]]
@@ -1192,17 +1192,14 @@ proc averageHeightAndDensity {residueDictonary outfiles lipidList zValsList} {
             set species [lindex $lipidList $indx]
             if {$leaf == 1} {
                 set field_key "z1z2"
-                set dens_key "density_up_${species}"
                 set height_key "heights_up"
                 set counts_key "counts_up"
             } elseif {$leaf == 2} {
                 set field_key "z1z2"
-                set dens_key "density_down_${species}"
                 set height_key "heights_down"
                 set counts_key "counts_down"
             } elseif {$leaf == 3} {
                 set field_key "z0"
-                set dens_key "density_zzero_${species}"
                 set height_key "heights_zzero"
                 set counts_key "counts_zzero"
             } else {
@@ -1216,17 +1213,10 @@ proc averageHeightAndDensity {residueDictonary outfiles lipidList zValsList} {
                 set newsum [expr {$oldavg * $oldcount + [lindex $zValsList $indx]}]
                 set newavg [expr $newsum/$newcount]
                 dict set outfiles $field_key $height_key bin $correct_bin $newavg
-                dict set outfiles $field_key $counts_key bin $correct_bin $newcount
-                if {[dict exists $outfiles $field_key $dens_key bin $correct_bin]} {
-                    set olddens [dict get $outfiles $field_key $dens_key bin $correct_bin]
-                    dict set outfiles $field_key $dens_key bin $correct_bin [expr $olddens+1.0]
-                } else {
-                    dict set outfiles $field_key $dens_key bin $correct_bin 1.0
-                }       
+                dict set outfiles $field_key $counts_key bin $correct_bin $newcount   
             } else {
                 dict set outfiles $field_key $height_key bin $correct_bin [lindex $zValsList $indx]
                 dict set outfiles $field_key $counts_key bin $correct_bin 1.0
-                dict set outfiles $field_key $dens_key bin $correct_bin 1.0
             }
         }
     }

--- a/utilities/helper_procs.tcl
+++ b/utilities/helper_procs.tcl
@@ -1327,7 +1327,7 @@ proc readPolar {polar} {
 #       creates dictionaries of atomselections  
 #       
 # Arguments:
-#       quantity            {str}       quanities being evaluated, either height_density or tilt_order       
+#       quantity            {str}       quanities being evaluated, either height or tilt_order       
 #       configDictionary    {dict}      dictionary of values created from the config file 
 #
 # Results:
@@ -1340,10 +1340,9 @@ proc readPolar {polar} {
 
 proc createAtomSelections {quantity configDictionary} {
     ;#atomselections setup as dict
-    if {$quantity eq "height_density"} {
+    if {$quantity eq "height"} {
         dict set selections z1z2 [atomselect top "resname [dict get $configDictionary species] and name [dict get $configDictionary full_tails]"]
         dict set selections z0 [atomselect top "resname [dict get $configDictionary species] and ((user 1 and within 6 of user 2) or (user 2 and within 6 of user 1))"]
-
     } elseif {$quantity eq "tilt_order"} {
         set lists [sortTailLength [dict get $configDictionary species] [dict get $configDictionary acyl_names]]
         set sellist [lindex $lists 0]

--- a/utilities/helper_procs.tcl
+++ b/utilities/helper_procs.tcl
@@ -553,13 +553,13 @@ proc assignBins {xVals yVals binWidth1 binWidth2 thetaDeg polar frm} {
 proc createOutfiles {quantity species tailList folderName} {
     file mkdir "${folderName}/tcl_output"
     
-    if {$quantity eq "height_density"} {
+    if {$quantity eq "height"} {
         set height "${folderName}/tcl_output/height"
         file mkdir $height
         dict set outfiles z1z2 heights_up fname [open "${height}/zone.dat" w]
         dict set outfiles z1z2 heights_down fname [open "${height}/ztwo.dat" w]
         dict set outfiles z0 heights_zzero fname [open "${height}/zzero.dat" w]
-
+    } elseif {$quantity eq "density"} {
         set density "${folderName}/tcl_output/density"
         file mkdir $density
         file mkdir "${density}/combined"


### PR DESCRIPTION
Completely remove density calculations from height calculations, as they are built off of different things (heights are based on lipid-level calculations regardless of lipid/tail identity). If density is re-implemented, it will make more sense with tilt/order calculations or as stand-alone.