### PR TITLE
Merging Unit test error flag

### DIFF
--- a/test/unit_test.test
+++ b/test/unit_test.test
@@ -806,6 +806,7 @@ test Avgheight {
     return $match
 } -result 12.49 -cleanup {
     mol delete top
+    exec rm -r PO_cart_12_12_0_1_1/
 }
 
 
@@ -839,4 +840,5 @@ test Avgdensity {
     return $match
 } -result 12.49 -cleanup {
     mol delete top
+    exec rm -r PO_cart_12_12_0_1_1/
 }

--- a/test/unit_test.test
+++ b/test/unit_test.test
@@ -1,7 +1,7 @@
 package require tcltest
 namespace import ::tcltest::*
 
-configure -verbose pbt
+configure -verbose pbt -skip "Avgtiltord Avgdensity"
 # Software under test
 
 source ../utilities/helper_procs.tcl

--- a/testing_materials/run_full_test_suite.bash
+++ b/testing_materials/run_full_test_suite.bash
@@ -14,7 +14,7 @@ vmd -dispdev none -e ./run_unit_tests.tcl > ../testing_materials/tcl_unit_test.l
 cd ../testing_materials/
 
 # Check to make sure VMD didn't error
-if [[grep "invalid command" tcl_unit_test.log || grep "bad option" tcl_unit_test.log || grep "couldn't load file" tcl_unit_test.log]]
+if grep -E 'invalid \command|bad \option|nt \load \file' tcl_unit_test.log
 then
 	echo "Something went wrong in VMD :("
 	echo "Your unit tests likely did not run."

--- a/testing_materials/run_full_test_suite.bash
+++ b/testing_materials/run_full_test_suite.bash
@@ -14,7 +14,7 @@ vmd -dispdev none -e ./run_unit_tests.tcl > ../testing_materials/tcl_unit_test.l
 cd ../testing_materials/
 
 # Check to make sure VMD didn't error
-if grep -E 'invalid \command|bad \option|nt \load \file' tcl_unit_test.log
+if grep -E 'invalid \command|bad \option|nt \load \file|unknown \option' tcl_unit_test.log
 then
 	echo "Something went wrong in VMD :("
 	echo "Your unit tests likely did not run."

--- a/testing_materials/run_full_test_suite.bash
+++ b/testing_materials/run_full_test_suite.bash
@@ -14,7 +14,7 @@ vmd -dispdev none -e ./run_unit_tests.tcl > ../testing_materials/tcl_unit_test.l
 cd ../testing_materials/
 
 # Check to make sure VMD didn't error
-if grep "couldn't load file" tcl_unit_test.log
+if [[grep "invalid command" tcl_unit_test.log || grep "bad option" tcl_unit_test.log || grep "couldn't load file" tcl_unit_test.log]]
 then
 	echo "Something went wrong in VMD :("
 	echo "Your unit tests likely did not run."
@@ -30,22 +30,6 @@ fi
 
 # Check to make sure tests all passed
 if grep FAILED tcl_unit_test.log
-then
-	echo "TCL unit testing failed :("
-	echo "Do you want to continue with acceptance testing anyway?"
-	echo "(Choose the number that corresponds to your choice)"
-	select yn in "Yes, Continue" "No, Exit"; do
-    	case $yn in
-        	"Yes, Continue" ) break;;
-        	"No, Exit" ) exit;;
-    	esac
-	done
-else
-	echo "TCL unit testing passed :)"
-fi
-
-# Check to make sure tests all passed
-if grep "invalid command" tcl_unit_test.log
 then
 	echo "TCL unit testing failed :("
 	echo "Do you want to continue with acceptance testing anyway?"

--- a/testing_materials/run_full_test_suite.bash
+++ b/testing_materials/run_full_test_suite.bash
@@ -44,6 +44,22 @@ else
 	echo "TCL unit testing passed :)"
 fi
 
+# Check to make sure tests all passed
+if grep "invalid command" tcl_unit_test.log
+then
+	echo "TCL unit testing failed :("
+	echo "Do you want to continue with acceptance testing anyway?"
+	echo "(Choose the number that corresponds to your choice)"
+	select yn in "Yes, Continue" "No, Exit"; do
+    	case $yn in
+        	"Yes, Continue" ) break;;
+        	"No, Exit" ) exit;;
+    	esac
+	done
+else
+	echo "TCL unit testing passed :)"
+fi
+
 # Run python unit tests and divert output to file and terminal.
 echo "Starting pytest unit testing"
 python3 -m pytest ../test/Unit_Test.py 2>&1 | tee -a pyunittest.log


### PR DESCRIPTION
After much battling with tcltest, there is now a skip option on line 4. There are also now more error checks in run_full_test_suite.bash to handle weird vmd/tcltest edge cases