### PR TITLE
Fixed bug from dict remove as well as removed directories that are no longer implemented

### DIFF
--- a/nougat.tcl
+++ b/nougat.tcl
@@ -233,8 +233,8 @@ proc run_nougat {system config_dict bindims polar quantity_of_interest foldernam
             } 
 
             ;# cleanup before next step
-            dict remove res_dict
-            dict remove sel_info
+            dict remove $res_dict [dict keys $res_dict]
+            dict remove $sel_info [dict keys $sel_info]
         }
     }
 

--- a/plotting/utils.py
+++ b/plotting/utils.py
@@ -98,8 +98,10 @@ def create_outfile_directories(cwd):
     None.
 
     """
+    #quantities = ["height", "density", "curvature", "thickness", "order", "tilt", "misc"]
+    quantities = ["height", "curvature", "thickness"]
     for filetype in ["trajectory", "average", "figures"]:
-        for quantity in ["height", "density", "curvature", "thickness", "order", "tilt", "misc"]:
+        for quantity in quantities:
             if quantity == "curvature":
                 for curv in ["mean", "gaussian", "normal_vectors"]:
                     dirname = cwd.joinpath(filetype, quantity, curv)


### PR DESCRIPTION
Two changes:

1) the cleanup statements on lines 236-237 were only working on lab workstations. On non-lab workstations they caused an error (see C4L slack). These have been fixed.

2) nougat.py was still outputting directories for density, tilt, and order. This has been fixed.