### PR TITLE
311 regenerate acc ref data

### DIFF
--- a/plotting/nougat.py
+++ b/plotting/nougat.py
@@ -391,7 +391,7 @@ class Field:
         field_data = mostly_empty(field_data)
         return field_data
 
-    def save_to_file(self, path, file_type):
+    def save_to_file(self, path, file_type, name=None):
         """
         Save the trajectory or average to file.
 
@@ -401,16 +401,21 @@ class Field:
             The path to the directory where you would like to save the file.
         file_type : str
             "trajectory" or "average".
+        name : str
+            The file name you wish to use, without a suffix. Default is the \
+            name of the field (self.name).
 
         Returns
         -------
         None.
 
         """
+        if name is None:
+            name = self.name
         if file_type == "trajectory":
-            np.save(path.joinpath(self.name + ".npy"), self.traj._traj_to_3darray())
+            np.save(path.joinpath(name + ".npy"), self.traj._traj_to_3darray())
         elif file_type == "average":
-            np.savetxt(path.joinpath(self.name + ".dat"), self.traj.avg())
+            np.savetxt(path.joinpath(name + ".dat"), self.traj.avg())
 
     # BASIC MATH MAGIC METHODS BELOW #
     # These make it so that you can do math on the Field object, rather than\

--- a/plotting/nougat.py
+++ b/plotting/nougat.py
@@ -415,7 +415,7 @@ class Field:
         if file_type == "trajectory":
             np.save(path.joinpath(name + ".npy"), self.traj._traj_to_3darray())
         elif file_type == "average":
-            np.savetxt(path.joinpath(name + ".dat"), self.traj.avg())
+            np.savetxt(path.joinpath(name + ".dat"), np.round(self.traj.avg(), decimals=5), delimiter=",")
 
     # BASIC MATH MAGIC METHODS BELOW #
     # These make it so that you can do math on the Field object, rather than\

--- a/testing_materials/regen_acc_test_data.py
+++ b/testing_materials/regen_acc_test_data.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Aug 26 12:16:04 2024
+
+@author: js2746
+"""
+import shutil
+from nougat import run_nougat
+
+
+def overwrite_ref_data_directories(path):
+    """
+    Create the preliminary directory hierarchy for nougat.py reference outputs.
+
+    Parameters
+    ----------
+    path  :  Path object
+        the path to the desired outfiles directory.
+
+    Returns
+    -------
+    None.
+
+    """
+    quantities = ["height", "curvature", "thickness"]
+    for filetype in ["trajectory", "average", "figures"]:
+        for quantity in quantities:
+            if quantity == "curvature":
+                for curv in ["mean", "gaussian", "normal_vectors"]:
+                    shutil.rmtree(path, ignore_errors=True)
+                    dirname = path.joinpath(filetype, quantity, curv)
+                    dirname.mkdir(parents=True, exist_ok=True)
+            else:
+                shutil.rmtree(path, ignore_errors=True)
+                dirname = path.joinpath(filetype, quantity)
+                dirname.mkdir(parents=True, exist_ok=True)
+
+
+def regenerate_ref_data(path, polar):
+    """
+    Run nougat on the test system and print the correct fields to file with \
+    naming convention that matches acceptance testing.
+
+    Parameters
+    ----------
+    path : Path or str
+        The path to the directory above the tcl_outputs directory for the test\
+        system.
+    polar : bool
+        If True, use polar coordinates. If False, use Cartesian.
+
+    Returns
+    -------
+    None.
+
+    """
+    m = run_nougat(path, polar)
+
+    height = m.children['z']
+    height_zero = m.children['z_zero']
+
+    thickness = m.children['t']
+
+    mean_curv = m.children['H']
+    mean_zero = m.children['h_zero']
+
+    gauss_curv = m.children['K']
+    gauss_plus = m.children['k_plus']
+    gauss_zero = m.children['k_zero']
+
+    height.outer.print_to_file(path.joinpath('zone'))

--- a/testing_materials/regen_acc_test_data.py
+++ b/testing_materials/regen_acc_test_data.py
@@ -33,7 +33,7 @@ def regenerate_ref_data(path, polar):
     None.
 
     """
-    m = run_nougat(path, polar)
+    m = run_nougat(path, polar, 'hct')
 
     height = m.children['z']
     height_zero = m.children['z_zero']

--- a/testing_materials/regen_acc_test_data.py
+++ b/testing_materials/regen_acc_test_data.py
@@ -5,10 +5,14 @@ Created on Mon Aug 26 12:16:04 2024.
 
 @author: js2746
 """
-from nougat import run_nougat
 from pathlib import Path
 import argparse
 from shutil import rmtree
+import os
+import sys
+
+sys.path.append(os.path.abspath('../plotting/'))
+from nougat import run_nougat
 
 
 def regenerate_ref_data(path, polar):

--- a/testing_materials/regen_acc_test_data.py
+++ b/testing_materials/regen_acc_test_data.py
@@ -7,32 +7,7 @@ Created on Mon Aug 26 12:16:04 2024
 """
 from nougat import run_nougat
 from pathlib import Path
-
-
-def create_ref_data_directories(path):
-    """
-    Create the preliminary directory hierarchy for nougat.py reference outputs.
-
-    Parameters
-    ----------
-    path  :  Path object
-        the path to the desired outfiles directory.
-
-    Returns
-    -------
-    None.
-
-    """
-    quantities = ["height", "curvature", "thickness"]
-    for filetype in ["trajectory", "average", "figures"]:
-        for quantity in quantities:
-            if quantity == "curvature":
-                for curv in ["mean", "gaussian", "normal_vectors"]:
-                    dirname = path.joinpath(filetype, quantity, curv)
-                    dirname.mkdir(parents=True, exist_ok=True)
-            else:
-                dirname = path.joinpath(filetype, quantity)
-                dirname.mkdir(parents=True, exist_ok=True)
+import argparse
 
 
 def regenerate_ref_data(path, polar):
@@ -68,24 +43,38 @@ def regenerate_ref_data(path, polar):
     gauss_zero = m.children['k_zero']
 
     for filetype in ['trajectory', 'average']:
-        height.outer.save_to_file(path.joinpath(filetype, 'height'), filetype, name="zone")
-        height.inner.save_to_file(path.joinpath(filetype, 'height'), filetype, name="ztwo")
-        height.plus.save_to_file(path.joinpath(filetype, 'height'), filetype, name="zplus")
-        height_zero.save_to_file(path.joinpath(filetype, 'height'), filetype, name="zzero")
+        dirname = path.joinpath(filetype, 'height')
+        dirname.mkdir(parents=True, exist_ok=False)
+        height.outer.save_to_file(dirname, filetype, name="zone")
+        height.inner.save_to_file(dirname, filetype, name="ztwo")
+        height.plus.save_to_file(dirname, filetype, name="zplus")
+        height_zero.save_to_file(dirname, filetype, name="zzero")
 
-        thickness.outer.save_to_file(path.joinpath(filetype, 'thickness'), filetype, name="zone")
-        thickness.inner.save_to_file(path.joinpath(filetype, 'thickness'), filetype, name="ztwo")
+        dirname = path.joinpath(filetype, 'thickness')
+        dirname.mkdir(parents=True, exist_ok=False)
+        thickness.outer.save_to_file(dirname, filetype, name="zone")
+        thickness.inner.save_to_file(dirname, filetype, name="ztwo")
 
-        mean_curv.outer.save_to_file(path.joinpath(filetype, 'curvature', 'mean'), filetype, name="zone")
-        mean_curv.inner.save_to_file(path.joinpath(filetype, 'curvature', 'mean'), filetype, name="ztwo")
-        mean_curv.plus.save_to_file(path.joinpath(filetype, 'curvature', 'mean'), filetype, name="zplus")
-        mean_zero.save_to_file(path.joinpath(filetype, 'curvature', 'mean'), filetype, name="zzero")
+        dirname = path.joinpath(filetype, 'curvature', 'mean')
+        dirname.mkdir(parents=True, exist_ok=False)
+        mean_curv.outer.save_to_file(dirname, filetype, name="zone")
+        mean_curv.inner.save_to_file(dirname, filetype, name="ztwo")
+        mean_curv.plus.save_to_file(dirname, filetype, name="zplus")
+        mean_zero.save_to_file(dirname, filetype, name="zzero")
 
-        gauss_curv.outer.save_to_file(path.joinpath(filetype, 'curvature', 'gaussian'), filetype, name="zone")
-        gauss_curv.inner.save_to_file(path.joinpath(filetype, 'curvature', 'gaussian'), filetype, name="ztwo")
-        gauss_plus.save_to_file(path.joinpath(filetype, 'curvature', 'mean'), filetype, name="zplus")
-        gauss_zero.save_to_file(path.joinpath(filetype, 'curvature', 'mean'), filetype, name="zzero")
+        dirname = path.joinpath(filetype, 'curvature', 'gaussian')
+        dirname.mkdir(parents=True, exist_ok=False)
+        gauss_curv.outer.save_to_file(dirname, filetype, name="zone")
+        gauss_curv.inner.save_to_file(dirname, filetype, name="ztwo")
+        gauss_plus.save_to_file(dirname, filetype, name="zplus")
+        gauss_zero.save_to_file(dirname, filetype, name="zzero")
 
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Regenerate reference data files for acceptance testing.")
+    parser.add_argument("path", default=".", help="the path to the directory above your tcl_outputs folder")
+    parser.add_argument("-p", "--polar", action="store_true", help="add this flag if you ran nougat.tcl with polar coordinates")
+
+    args = parser.parse_args()
+    path = Path(args.path)
     

--- a/testing_materials/regen_acc_test_data.py
+++ b/testing_materials/regen_acc_test_data.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Created on Mon Aug 26 12:16:04 2024
+Created on Mon Aug 26 12:16:04 2024.
 
 @author: js2746
 """
@@ -77,4 +77,4 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     path = Path(args.path)
-    
+    regenerate_ref_data(path, args.polar)

--- a/testing_materials/regen_acc_test_data.py
+++ b/testing_materials/regen_acc_test_data.py
@@ -7,6 +7,7 @@ Created on Mon Aug 26 12:16:04 2024
 """
 import shutil
 from nougat import run_nougat
+import pathlib
 
 
 def overwrite_ref_data_directories(path):
@@ -69,4 +70,21 @@ def regenerate_ref_data(path, polar):
     gauss_plus = m.children['k_plus']
     gauss_zero = m.children['k_zero']
 
-    height.outer.print_to_file(path.joinpath('zone'))
+    for filetype in ['trajectory', 'average']:
+        height.outer.save_to_file(path.joinpath(filetype, 'height'), filetype, name="zone")
+        height.inner.save_to_file(path.joinpath(filetype, 'height'), filetype, name="ztwo")
+        height.plus.save_to_file(path.joinpath(filetype, 'height'), filetype, name="zplus")
+        height_zero.save_to_file(path.joinpath(filetype, 'height'), filetype, name="zzero")
+
+        thickness.outer.save_to_file(path.joinpath(filetype, 'thickness'), filetype, name="zone")
+        thickness.inner.save_to_file(path.joinpath(filetype, 'thickness'), filetype, name="ztwo")
+
+        mean_curv.outer.save_to_file(path.joinpath(filetype, 'curvature', 'mean'), filetype, name="zone")
+        mean_curv.inner.save_to_file(path.joinpath(filetype, 'curvature', 'mean'), filetype, name="ztwo")
+        mean_curv.plus.save_to_file(path.joinpath(filetype, 'curvature', 'mean'), filetype, name="zplus")
+        mean_zero.save_to_file(path.joinpath(filetype, 'curvature', 'mean'), filetype, name="zzero")
+
+        gauss_curv.outer.save_to_file(path.joinpath(filetype, 'curvature', 'gaussian'), filetype, name="zone")
+        gauss_curv.inner.save_to_file(path.joinpath(filetype, 'curvature', 'gaussian'), filetype, name="ztwo")
+        gauss_plus.save_to_file(path.joinpath(filetype, 'curvature', 'mean'), filetype, name="zplus")
+        gauss_zero.save_to_file(path.joinpath(filetype, 'curvature', 'mean'), filetype, name="zzero")

--- a/testing_materials/regen_acc_test_data.py
+++ b/testing_materials/regen_acc_test_data.py
@@ -8,6 +8,7 @@ Created on Mon Aug 26 12:16:04 2024.
 from nougat import run_nougat
 from pathlib import Path
 import argparse
+from shutil import rmtree
 
 
 def regenerate_ref_data(path, polar):
@@ -74,7 +75,12 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Regenerate reference data files for acceptance testing.")
     parser.add_argument("path", default=".", help="the path to the directory above your tcl_outputs folder")
     parser.add_argument("-p", "--polar", action="store_true", help="add this flag if you ran nougat.tcl with polar coordinates")
+    parser.add_argument("-o", "--overwrite", action="store_true", help="add this flag if you want to overwrite existing python outputs")
 
     args = parser.parse_args()
     path = Path(args.path)
+
+    if args.overwrite:
+        rmtree(path.joinpath('trajectory'))
+        rmtree(path.joinpath('average'))
     regenerate_ref_data(path, args.polar)

--- a/testing_materials/regen_acc_test_data.py
+++ b/testing_materials/regen_acc_test_data.py
@@ -5,12 +5,11 @@ Created on Mon Aug 26 12:16:04 2024
 
 @author: js2746
 """
-import shutil
 from nougat import run_nougat
-import pathlib
+from pathlib import Path
 
 
-def overwrite_ref_data_directories(path):
+def create_ref_data_directories(path):
     """
     Create the preliminary directory hierarchy for nougat.py reference outputs.
 
@@ -29,11 +28,9 @@ def overwrite_ref_data_directories(path):
         for quantity in quantities:
             if quantity == "curvature":
                 for curv in ["mean", "gaussian", "normal_vectors"]:
-                    shutil.rmtree(path, ignore_errors=True)
                     dirname = path.joinpath(filetype, quantity, curv)
                     dirname.mkdir(parents=True, exist_ok=True)
             else:
-                shutil.rmtree(path, ignore_errors=True)
                 dirname = path.joinpath(filetype, quantity)
                 dirname.mkdir(parents=True, exist_ok=True)
 
@@ -88,3 +85,7 @@ def regenerate_ref_data(path, polar):
         gauss_curv.inner.save_to_file(path.joinpath(filetype, 'curvature', 'gaussian'), filetype, name="ztwo")
         gauss_plus.save_to_file(path.joinpath(filetype, 'curvature', 'mean'), filetype, name="zplus")
         gauss_zero.save_to_file(path.joinpath(filetype, 'curvature', 'mean'), filetype, name="zzero")
+
+
+if __name__ == '__main__':
+    

--- a/testing_materials/regen_acc_test_data.sh
+++ b/testing_materials/regen_acc_test_data.sh
@@ -9,21 +9,10 @@ vmd -dispdev none -e ./regen_acc_test_data.tcl
 
 # Add any systems you want nougat to run below
 
-cd ./E-protein_trajectory/E-protein_cart_5_5_0_-1_1
-python3 ../../../plotting/nougat.py
-cd ../..
-
-cd ./E-protein_trajectory/E-protein_polar_3_12_0_-1_1
-python3 ../../../plotting/nougat.py -p
-cd ../..
-
-cd ./flat_surface_test/flat_cart_5_5_0_-1_1
-python3 ../../../plotting/nougat.py
-cd ../..
-
-cd ./flat_surface_test/flat_polar_3_12_0_-1_1
-python3 ../../../plotting/nougat.py -p
-cd ../..
+python3 regen_acc_test_data.py ./E-protein_trajectory/E-protein_cart_5_5_0_-1_1
+python3 regen_acc_test_data.py ./E-protein_trajectory/E-protein_polar_3_12_0_-1_1 -p
+python3 regen_acc_test_data.py ./flat_surface_test/flat_cart_5_5_0_-1_1
+python3 regen_acc_test_data.py ./flat_surface_test/flat_polar_3_12_0_-1_1 -p
 
 git add ./E-protein_trajectory/E-protein_*
 git add ./flat_surface_test/flat_*

--- a/testing_materials/run_full_test_suite.bash
+++ b/testing_materials/run_full_test_suite.bash
@@ -83,7 +83,7 @@ echo "Starting acceptance testing"
 vmd -dispdev none -e ./run_nougat_test.tcl > nougat_test_outputs.log
 
 # Run acceptance tests on resulting files
-python3 -m pytest tests/ 2>&1 | tee -a pytest.log
+python3 -m pytest -rx tests/ 2>&1 | tee -a pytest.log
 
 # Sound the all clear
 echo "Acceptance testing finished"

--- a/testing_materials/tests/test_nougat_outputs.py
+++ b/testing_materials/tests/test_nougat_outputs.py
@@ -94,6 +94,7 @@ def membrane(cwd, coordsys, system):
         polar = True
     test_root_path = make_root_path(cwd, coordsys, system, test=True)
     m = run_nougat(test_root_path, polar, "htc")
+    m.dump(test_root_path)
     return m
 
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%% FUNCTIONS %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -392,7 +393,6 @@ def test_if_avgs_match(cwd, coordsys, surface4, system, quantity, membrane):
     ref = np.genfromtxt(ref_path, delimiter=",", missing_values="nan", filling_values=np.nan)
 
     test_array = np.round(surf.traj.avg(), decimals=5)
-
     assert arrays_equal(ref, test_array, 1e-11)
 
 


### PR DESCRIPTION
This PR allows us to regenerate reference values for the acceptance testing. This would be necessary if we implement a new feature, realize the reference data was wrong for some reason, or want to change formatting in any way, among other reasons.

It does the following:

- creates a new python file called regen_acc_test_data.py, which runs nougat on TCL reference values and saves each field to file in the necessary file structure/naming convention required by acceptance testing
- revises regen_acc_test_data.sh to use the new .py script
- allows the user to specify a filename when saving a Field object to file with save_to_file
- additional minor changes:
   - acceptance testing now dumps to file (gets deleted if all tests pass, useful for debugging)
   - acceptance tests now print from stdout upon test fail (useful for debugging)