### PR TITLE
330 implement option for no wrapping

### DIFF
--- a/nougat.tcl
+++ b/nougat.tcl
@@ -64,19 +64,14 @@ proc cell_prep {config_path leaf_check} {
 
     set end [molinfo top get numframes]
 
-    ;# center, wrap, and align the system
+    ;# wrap the system
     if {[dict get $config_dict use_qwrap] == "yes"} {
         run_qwrap [dict get $config_dict wrap_sel] [dict get $config_dict inclusion_sel]
-    } else {
+    } elseif {[dict get $config_dict inclusion_sel] != "NULL"} {
         pbc wrap -all -center bb -centersel [dict get $config_dict inclusion_sel] 
-        set sel [atomselect top all]
-        for {set i 0} {$i<$end} {incr i} {
-            $sel frame $i
-            $sel update
-            set center [measure center $sel]
-            $sel moveby "[expr -1*[lindex $center 0]] [expr -1*[lindex $center 1]] 0"
-        }
-        $sel delete
+        center_system $end
+    } else {
+        center_system $end
     }
 
     # align the system, removing xy rotation

--- a/nougat.tcl
+++ b/nougat.tcl
@@ -64,7 +64,7 @@ proc cell_prep {config_path leaf_check} {
 
     set end [molinfo top get numframes]
 
-    ;# wrap the system
+    ;# wrap and center the system
     if {[dict get $config_dict use_qwrap] == "yes"} {
         run_qwrap [dict get $config_dict wrap_sel] [dict get $config_dict inclusion_sel]
     } elseif {[dict get $config_dict inclusion_sel] != "NULL"} {

--- a/utilities/helper_procs.tcl
+++ b/utilities/helper_procs.tcl
@@ -1599,6 +1599,18 @@ proc get_theta {x y} {
     return [convertRadianToDegree $theta]
 }
 
+;# Centers system at origin
+proc center_system {end} {
+    set sel [atomselect top all]
+    for {set i 0} {$i<$end} {incr i} {
+        $sel frame $i
+        $sel update
+        set center [measure center $sel]
+        $sel moveby "[expr -1*[lindex $center 0]] [expr -1*[lindex $center 1]] 0"
+    }
+    $sel delete
+}
+
 ;# Ouputs position of the centered protein in a membrane
 ;# accross both leaflets
 ;# only useful for analysis later - doesn't impact your polar density script


### PR DESCRIPTION
This PR allows for the user to _not_ wrap their system (for instance if there is no protein present). The documentation indicated that the user should just make inclusion_sel "NULL", but doing this caused an error. This is fixed now.