### PR TITLE
vmd now recognized by unit tests script

### DIFF
--- a/testing_materials/run_full_test_suite.bash
+++ b/testing_materials/run_full_test_suite.bash
@@ -1,5 +1,9 @@
 #! /bin/bash
 
+# Allow bash aliases (specifically 'vmd')
+shopt -s expand_aliases
+source ~/.bashrc
+
 # Remove old log files to prevent accidental appending. -f is to suppress
 # error if no such file exists.
 rm -f nougpy.log
@@ -11,6 +15,13 @@ rm -f nougat_test_outputs.log
 # Run tcl unit tests and divert output to file
 echo "Starting TCL unit testing"
 vmd -dispdev none -eofexit < ../test/unit_test.test > ./tcl_unit_test.log
+
+# Check to make sure VMD exists
+if [ ! -s tcl_unit_test.log ]
+then
+	echo "VMD is not recognized or not installed."
+	exit
+fi
 
 # Check to make sure VMD didn't error
 if grep -E 'invalid \command|bad \option|nt \load \file|unknown \option' tcl_unit_test.log


### PR DESCRIPTION
This PR fixes issue #338. It implements two fixes:

1. The unit test script will now allow for the use of aliases (so bash will know what 'vmd' means).
2. If VMD didn't run for some reason (it's not installed or the user hasn't aliased it/put it on path) unit testing will now fail.