### PR TITLE
changed math magic methods to use _traj_to_3darray

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -166,12 +166,10 @@ if __name__ == "__main__":
 
     if args.inclusion:
         m.add_protein_helices(path)
-    
+
     print(m.helix_locations['zone'])
 
     fig, ax = m.plot2d(getattr(m.children['z'], 'outer'), 15, -15, helix_surface='zone')
-
-    plt.show()
 
     if args.dump:
         m.dump(path)

--- a/python/nougat.py
+++ b/python/nougat.py
@@ -467,63 +467,63 @@ class Field:
     def __add__(self, other):
         """Use numpy to add things together."""
         if isinstance(other, Field):
-            return self.traj + other.traj
+            return self.traj._traj_to_3darray() + other.traj._traj_to_3darray()
         elif isinstance(other, (np.ndarray, int, float)):
-            return self.traj + other
+            return self.traj._traj_to_3darray() + other
         else:
             return NotImplemented
 
     def __radd__(self, other):
         """Use numpy to add things together."""
         if isinstance(other, (np.ndarray, int, float)):
-            return self.traj + other
+            return self.traj._traj_to_3darray() + other
         else:
             return NotImplemented
 
     def __sub__(self, other):
         """Use numpy to subtract things."""
         if isinstance(other, Field):
-            return self.traj - other.traj
+            return self.traj._traj_to_3darray() - other.traj._traj_to_3darray()
         elif isinstance(other, (np.ndarray, int, float)):
-            return self.traj - other
+            return self.traj._traj_to_3darray() - other
         else:
             return NotImplemented
 
     def __rsub__(self, other):
         """Use numpy to subtract things."""
         if isinstance(other, (np.ndarray, int, float)):
-            return other - self.traj
+            return other - self.traj._traj_to_3darray()
         else:
             return NotImplemented
 
     def __mul__(self, other):
         """Use numpy to multiply things together."""
         if isinstance(other, Field):
-            return self.traj * other.traj
+            return self.traj._traj_to_3darray() * other.traj._traj_to_3darray()
         elif isinstance(other, (np.ndarray, int, float)):
-            return self.traj * other
+            return self.traj._traj_to_3darray() * other
         else:
             return NotImplemented
 
     def __rmul__(self, other):
         """Use numpy to multiply things together."""
         if isinstance(other, (np.ndarray, int, float)):
-            return self.traj * other
+            return self.traj._traj_to_3darray() * other
         else:
             return NotImplemented
 
     def __div__(self, other):
         """Use numpy to divide things."""
         if isinstance(other, Field):
-            return self.traj / other.traj
+            return self.traj._traj_to_3darray() / other.traj._traj_to_3darray()
         elif isinstance(other, (np.ndarray, int, float)):
-            return self.traj / other
+            return self.traj._traj_to_3darray() / other
         else:
             return NotImplemented
 
     def __pow__(self, exponent):
         """Use numpy's power() on the array stored in this Field."""
-        return np.power(self.traj, exponent)
+        return np.power(self.traj._traj_to_3darray(), exponent)
 
 
 class Trajectory:
@@ -649,65 +649,65 @@ class Trajectory:
     def __add__(self, other):
         """Use numpy to add things together."""
         if isinstance(other, Trajectory):
-            return self.frames + other.frames
+            return self._traj_to_3darray() + other._traj_to_3darray()
         elif isinstance(other, (np.ndarray, int, float)):
-            return self.frames + other
+            return self._traj_to_3darray() + other
         else:
             return NotImplemented
 
     def __radd__(self, other):
         """Use numpy to add things together."""
         if isinstance(other, (np.ndarray, int, float)):
-            return self.frames + other
+            return self._traj_to_3darray() + other
         else:
             return NotImplemented
 
     def __sub__(self, other):
         """Use numpy to subtract things."""
         if isinstance(other, Trajectory):
-            return self.frames - other.frames
+            return self._traj_to_3darray() - other._traj_to_3darray()
         elif isinstance(other, (np.ndarray, int, float)):
-            return self.frames - other
+            return self._traj_to_3darray() - other
         else:
             return NotImplemented
 
     def __rsub__(self, other):
         """Use numpy to subtract things."""
         if isinstance(other, Trajectory):
-            return other.frames - self.frames
+            return other._traj_to_3darray() - self._traj_to_3darray()
         elif isinstance(other, (np.ndarray, int, float)):
-            return other - self.frames
+            return other - self._traj_to_3darray()
         else:
             return NotImplemented
 
     def __mul__(self, other):
         """Use numpy to multiply things together."""
         if isinstance(other, Trajectory):
-            return self.frames * other.frames
+            return self._traj_to_3darray() * other._traj_to_3darray()
         elif isinstance(other, (np.ndarray, int, float)):
-            return self.frames * other
+            return self._traj_to_3darray() * other
         else:
             return NotImplemented
 
     def __rmul__(self, other):
         """Use numpy to multiply things together."""
         if isinstance(other, (np.ndarray, int, float)):
-            return self.frames * other
+            return self._traj_to_3darray() * other
         else:
             return NotImplemented
 
     def __div__(self, other):
         """Use numpy to divide things."""
         if isinstance(other, Trajectory):
-            return self.frames / other.frames
+            return self._traj_to_3darray() / other._traj_to_3darray()
         elif isinstance(other, (np.ndarray, int, float)):
-            return self.frames / other
+            return self._traj_to_3darray() / other
         else:
             return NotImplemented
 
     def __pow__(self, exponent):
         """Use numpy's power() on the array stored in this Field."""
-        return np.power(self.frames, exponent)
+        return np.power(self._traj_to_3darray(), exponent)
 
 
 class Frame:


### PR DESCRIPTION
All math magic methods for Fields and Trajectories now make use of the _traj_to_3darray Trajectory method instead of relying on __array__ to work correctly, which it was not doing in some instances.