### PR TITLE
362 numpy std underestimates std

### DIFF
--- a/python/nougat.py
+++ b/python/nougat.py
@@ -611,7 +611,7 @@ class Trajectory:
         data_array = self._traj_to_3darray()
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
-            stdev = np.nanstd(data_array, axis=0)
+            stdev = np.nanstd(data_array, axis=0, ddof=1)
             return stdev
 
     def avg_over_theta(self):

--- a/python/nougat.py
+++ b/python/nougat.py
@@ -625,15 +625,11 @@ class Trajectory:
     def stdev_over_theta(self):
         """Calculate standard deviation of time averages, averaged over theta."""
         assert self.polar, "Trajectory must be polar in order to average over theta."
-        stdev2 = np.square(self.stdev())
-        num_samples = np.sum(~np.isnan(stdev2), axis=1)
-        num_samples[num_samples == 0] = np.nan
+        time_avg = self.avg()
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
-            sums_over_theta = np.nansum(stdev2, axis=1)
-            sqrt_over_theta = np.sqrt(sums_over_theta)
-            avg_stdev_over_theta = sqrt_over_theta / num_samples
-            return avg_stdev_over_theta
+            stdev_over_theta = np.nanstd(time_avg, axis=1, ddof=1)
+            return stdev_over_theta
 
     def __getitem__(self, item):
         """Make Trajectory object subscriptable."""

--- a/python/nougat.py
+++ b/python/nougat.py
@@ -625,10 +625,10 @@ class Trajectory:
     def stdev_over_theta(self):
         """Calculate standard deviation of time averages, averaged over theta."""
         assert self.polar, "Trajectory must be polar in order to average over theta."
-        time_avg = self.avg()
+        time_avg_2d = self.avg()
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
-            stdev_over_theta = np.nanstd(time_avg, axis=1, ddof=1)
+            stdev_over_theta = np.nanstd(time_avg_2d, axis=1, ddof=1)
             return stdev_over_theta
 
     def __getitem__(self, item):


### PR DESCRIPTION
## Description
This PR adds the ddof=1 argument to nougat's standard deviation calculations. It also changes stdev_over_theta to be more straightforward (it had formerly been propagating the error in an unecessary and unexpected way; now it just calculates the stdev over theta)

## Usage Changes
None

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] added ddof=1 to stdev() method
  - [x] changed stdev_over_theta() method to calculate the standard deviation over theta, rather than attempting to propagate the error present in the time averages

## Pre-Review checklist (PR maker)
- [x] Run nougat acceptance testing

## Review checklist (Reviewer)
- [x] No missed "low-hanging fruit" that would substantially aid readability.
- [x] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [x] [optional] run nougat acceptance testing
- [x] I understand what the changes are doing and how
- [x] I understand the motivation for this PR (the PR itself is appropriately documented)

## Status
- [x] Ready for review