### PR TITLE
386 analyzetails does not work for fatty acids or updated CDL

### DIFF
--- a/tcl/nougat.tcl
+++ b/tcl/nougat.tcl
@@ -92,7 +92,7 @@ proc cell_prep {config_path leaf_check} {
     if {$leaf_check == 1} {
         for {set i 0} {$i < $end} {incr i} {
             puts "leaflet check frame $i"
-            assignLeaflet $i $species $heads_and_tails 1.0 [dict get $config_dict pore_sorter]
+            assignLeaflet $i $species $heads_and_tails 1.0
         }
     }
 
@@ -173,7 +173,7 @@ proc run_nougat {system config_dict bindims polar quantity_of_interest foldernam
 
         ;# update leaflets in case lipids have flip-flopped
 
-        assignLeaflet $frm [dict get $config_dict species] [dict get $config_dict heads_and_tails] 1.0 [dict get $config_dict pore_sorter]
+        assignLeaflet $frm [dict get $config_dict species] [dict get $config_dict heads_and_tails] 1.0
 
         puts "$system $quantity_of_interest $frm"
 

--- a/tcl/nougat.tcl
+++ b/tcl/nougat.tcl
@@ -92,7 +92,7 @@ proc cell_prep {config_path leaf_check} {
     if {$leaf_check == 1} {
         for {set i 0} {$i < $end} {incr i} {
             puts "leaflet check frame $i"
-            assignLeaflet $i $species $heads_and_tails 1.0 [dict get $config_dict pore_sorter]
+            assignLeaflet $i $species $heads_and_tails 1.0
         }
     }
 

--- a/tcl/nougat.tcl
+++ b/tcl/nougat.tcl
@@ -173,7 +173,7 @@ proc run_nougat {system config_dict bindims polar quantity_of_interest foldernam
 
         ;# update leaflets in case lipids have flip-flopped
 
-        assignLeaflet $frm [dict get $config_dict species] [dict get $config_dict heads_and_tails] 1.0 [dict get $config_dict pore_sorter]
+        assignLeaflet $frm [dict get $config_dict species] [dict get $config_dict heads_and_tails] 1.0
 
         puts "$system $quantity_of_interest $frm"
 

--- a/tcl/nougat.tcl
+++ b/tcl/nougat.tcl
@@ -92,7 +92,7 @@ proc cell_prep {config_path leaf_check} {
     if {$leaf_check == 1} {
         for {set i 0} {$i < $end} {incr i} {
             puts "leaflet check frame $i"
-            assignLeaflet $i $species $heads_and_tails 1.0
+            assignLeaflet $i $species $heads_and_tails 1.0 [dict get $config_dict pore_sorter]
         }
     }
 
@@ -173,7 +173,7 @@ proc run_nougat {system config_dict bindims polar quantity_of_interest foldernam
 
         ;# update leaflets in case lipids have flip-flopped
 
-        assignLeaflet $frm [dict get $config_dict species] [dict get $config_dict heads_and_tails] 1.0
+        assignLeaflet $frm [dict get $config_dict species] [dict get $config_dict heads_and_tails] 1.0 [dict get $config_dict pore_sorter]
 
         puts "$system $quantity_of_interest $frm"
 

--- a/tcl/utilities/helper_procs.tcl
+++ b/tcl/utilities/helper_procs.tcl
@@ -233,6 +233,10 @@ proc rotateSystem {axis degree start stop} {
 #       
 #       Each lipid will contain a user value corresponding to upper (1) or lower (2) leaflet
 #       or will be too sideways to tell which leaflet it's in (3)
+#
+# Necessary Revisions:
+#       - Needs to be revised to just take the 'top' bead in a lipid
+#       rather than hard-code PO4
 
 proc assignLeaflet {frm species tailTopsAndBottoms threshold poreSort} {
     foreach lipidType $species tailTipBeads [lindex $tailTopsAndBottoms 1] {

--- a/tcl/utilities/helper_procs.tcl
+++ b/tcl/utilities/helper_procs.tcl
@@ -397,6 +397,7 @@ proc analyzeTails { species } {
     set taillist []
     set letters "A B C D E F G H I J"
     set fatty_acids "ACA ACN UCA UCN LCA LCN PCA PCN BCA BCN XCA XCN"
+    set cardiolipins "CDL0 CDL1 CDL2"
     foreach lipidtype $species {
         set tails []
         set sel [atomselect top "resname $lipidtype"]
@@ -408,6 +409,9 @@ proc analyzeTails { species } {
         if {[lsearch $fatty_acids $lipidtype] != -1} {
             # Just remove the headgroup
             set tail [list [lrange $names 1 end] ]
+            lappend taillist $tail
+        } elseif {[lsearch $cardiolipins $lipidtype] != -1} {
+            set tail [list [list "C1A1 C2A1 D3A1 C4A1 C5A1"] [list "C1B1 C2B1 D3B1 C4B1 C5B1"] [list "C1A2 C2A2 D3A2 C4A2 C5A2"] [list "C1B2 C2B2 D3B2 C4B2 C5B2"] ]
             lappend taillist $tail
         } else {
             foreach letter $letters {

--- a/tcl/utilities/helper_procs.tcl
+++ b/tcl/utilities/helper_procs.tcl
@@ -234,7 +234,7 @@ proc rotateSystem {axis degree start stop} {
 #       Each lipid will contain a user value corresponding to upper (1) or lower (2) leaflet
 #       or will be too sideways to tell which leaflet it's in (3)
 
-proc assignLeaflet {frm species tailTopsAndBottoms threshold poreSort} {
+proc assignLeaflet {frm species tailTopsAndBottoms threshold} {
     foreach lipidType $species tailTipBeads [lindex $tailTopsAndBottoms 1] {
         set totalSel [atomselect top "resname $lipidType" frame $frm]
 
@@ -276,10 +276,6 @@ proc assignLeaflet {frm species tailTopsAndBottoms threshold poreSort} {
         
         $totalSel set user $userVals
         $totalSel delete
-    }
-    if {$poreSort ne "NULL"} {
-        ;# custom pore sorting proc for 5x29 and 7k3g
-        pore_sorter_custom $frm $species $poreSort
     }
 }
 

--- a/tcl/utilities/helper_procs.tcl
+++ b/tcl/utilities/helper_procs.tcl
@@ -243,7 +243,7 @@ proc assignLeaflet {frm species tailTopsAndBottoms threshold poreSort} {
         set speciesBeadNum [llength $beadNames]
         set numTails [llength $tailTipBeads]
 
-        set topBeadSel [atomselect top "resname $lipidType and name $topBead" frame $frm]
+        set topBeadSel [atomselect top "resname $lipidType and name PO4" frame $frm]
         set bottomBeadSel [atomselect top "resname $lipidType and name $tailTipBeads" frame $frm]
         set topBeadZ [$topBeadSel get z]
         set bottomBeadZ [$bottomBeadSel get z]

--- a/tcl/utilities/helper_procs.tcl
+++ b/tcl/utilities/helper_procs.tcl
@@ -244,7 +244,7 @@ proc assignLeaflet {frm species tailTopsAndBottoms threshold} {
         set numTails [llength $tailTipBeads]
 
         set topBeadSel [atomselect top "resname $lipidType and name $topBead" frame $frm]
-        set bottomBeadSel [atomselect top "resname $lipidType and name $tailTips" frame $frm]
+        set bottomBeadSel [atomselect top "resname $lipidType and name $tailTipBeads" frame $frm]
         set topBeadZ [$topBeadSel get z]
         set bottomBeadZ [$bottomBeadSel get z]
         $topBeadSel delete

--- a/tcl/utilities/helper_procs.tcl
+++ b/tcl/utilities/helper_procs.tcl
@@ -261,9 +261,9 @@ proc assignLeaflet {frm species tailTopsAndBottoms threshold} {
             set heightDiff [expr [lindex $topBeadZ $counter]-$avgEndHeight]
 
             ;# assign user value accordingly
-            if {$heightDiff > $window} {
+            if {$heightDiff > $threshold} {
                 lappend userList [lrepeat $speciesBeadNum 1.0]
-            } elseif {$heightDiff < -$window} {
+            } elseif {$heightDiff < - $threshold} {
                 lappend userList [lrepeat $speciesBeadNum 2.0]
             } else {
                 lappend userList [lrepeat $speciesBeadNum 3.0]

--- a/tcl/utilities/helper_procs.tcl
+++ b/tcl/utilities/helper_procs.tcl
@@ -228,6 +228,7 @@ proc rotateSystem {axis degree start stop} {
 #       species             {list}      list of lipid species in system
 #       tailTopsAndBottoms  {list}      list of first and last beads in each lipid tail
 #       threshold           {float}     If height difference is less than threshold, cannot determine leaflet
+#       poreSort            {str}       use custom pore sorter?
 #
 # Results:
 #       

--- a/tcl/utilities/helper_procs.tcl
+++ b/tcl/utilities/helper_procs.tcl
@@ -234,7 +234,7 @@ proc rotateSystem {axis degree start stop} {
 #       Each lipid will contain a user value corresponding to upper (1) or lower (2) leaflet
 #       or will be too sideways to tell which leaflet it's in (3)
 
-proc assignLeaflet {frm species tailTopsAndBottoms threshold} {
+proc assignLeaflet {frm species tailTopsAndBottoms threshold poreSort} {
     foreach lipidType $species tailTipBeads [lindex $tailTopsAndBottoms 1] {
         set totalSel [atomselect top "resname $lipidType" frame $frm]
 
@@ -276,6 +276,10 @@ proc assignLeaflet {frm species tailTopsAndBottoms threshold} {
         
         $totalSel set user $userVals
         $totalSel delete
+    }
+    if {$poreSort ne "NULL"} {
+        ;# custom pore sorting proc for 5x29 and 7k3g
+        pore_sorter_custom $frm $species $poreSort
     }
 }
 

--- a/tcl/utilities/helper_procs.tcl
+++ b/tcl/utilities/helper_procs.tcl
@@ -263,7 +263,7 @@ proc assignLeaflet {frm species tailTopsAndBottoms threshold} {
             ;# assign user value accordingly
             if {$heightDiff > $threshold} {
                 lappend userList [lrepeat $speciesBeadNum 1.0]
-            } elseif {$heightDiff < - $threshold} {
+            } elseif {$heightDiff < -$threshold} {
                 lappend userList [lrepeat $speciesBeadNum 2.0]
             } else {
                 lappend userList [lrepeat $speciesBeadNum 3.0]

--- a/testing_materials/tcltest/unit_test.test
+++ b/testing_materials/tcltest/unit_test.test
@@ -189,7 +189,7 @@ test basicleaflettop {
     Test: assignLeaflet
 } -setup {
    mol new ../lipid_membrane/insane2.gro
-   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 1 "NULL"
+   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 1 NULL
    set sel [atomselect top "resname POPC and z > 100"]
    set num [lsort -unique [$sel get user]]
 } -body {
@@ -202,7 +202,7 @@ test basicleafletbottom {
     Test: assignLeaflet
 } -setup {
    mol new ../lipid_membrane/insane2.gro
-   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 1 "NULL"
+   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 1 NULL
    set sel [atomselect top "resname POPC and z < 100"]
    set num [lsort -unique [$sel get user]]
 } -body {
@@ -215,7 +215,7 @@ test Singlelipidturned {
     Test: assignLeaflet
 } -setup {
    mol new ../lipid_membrane/fullmemsingletilt.gro
-   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 8 "NULL"
+   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 8 NULL
    set sel [atomselect top "resname POPC and resid 1000"]
    set num [lsort -unique [$sel get user]]
 } -body {
@@ -228,7 +228,7 @@ test Singlelipidturnedminwindow {
     Test: assignLeaflet
 } -setup {
    mol new ../lipid_membrane/fullmemsingletilt.gro
-   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 2 "NULL"
+   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 2 NULL
    set sel [atomselect top "resname POPC and resid 1000"]
    set num [lsort -unique [$sel get user]]
 } -body {

--- a/testing_materials/tcltest/unit_test.test
+++ b/testing_materials/tcltest/unit_test.test
@@ -189,7 +189,7 @@ test basicleaflettop {
     Test: assignLeaflet
 } -setup {
    mol new ../lipid_membrane/insane2.gro
-   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 1 NULL
+   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 1 NULL 
    set sel [atomselect top "resname POPC and z > 100"]
    set num [lsort -unique [$sel get user]]
 } -body {
@@ -202,7 +202,7 @@ test basicleafletbottom {
     Test: assignLeaflet
 } -setup {
    mol new ../lipid_membrane/insane2.gro
-   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 1 NULL
+   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 1 NULL 
    set sel [atomselect top "resname POPC and z < 100"]
    set num [lsort -unique [$sel get user]]
 } -body {
@@ -215,7 +215,7 @@ test Singlelipidturned {
     Test: assignLeaflet
 } -setup {
    mol new ../lipid_membrane/fullmemsingletilt.gro
-   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 8 NULL
+   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 8 NULL 
    set sel [atomselect top "resname POPC and resid 1000"]
    set num [lsort -unique [$sel get user]]
 } -body {
@@ -228,7 +228,7 @@ test Singlelipidturnedminwindow {
     Test: assignLeaflet
 } -setup {
    mol new ../lipid_membrane/fullmemsingletilt.gro
-   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 2 NULL
+   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 2 NULL 
    set sel [atomselect top "resname POPC and resid 1000"]
    set num [lsort -unique [$sel get user]]
 } -body {

--- a/testing_materials/tcltest/unit_test.test
+++ b/testing_materials/tcltest/unit_test.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::*
 
 cd ${argv}/tcltest/
-configure -verbose pbt -skip "Avgtiltord Avgdensity POPCbins"
+configure -verbose pbt -skip "Avgtiltord Avgdensity POPCbins Multitailnumbertails"
 
 # Software under test
 

--- a/testing_materials/tcltest/unit_test.test
+++ b/testing_materials/tcltest/unit_test.test
@@ -189,7 +189,7 @@ test basicleaflettop {
     Test: assignLeaflet
 } -setup {
    mol new ../lipid_membrane/insane2.gro
-   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 1 
+   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 1 "NULL"
    set sel [atomselect top "resname POPC and z > 100"]
    set num [lsort -unique [$sel get user]]
 } -body {
@@ -202,7 +202,7 @@ test basicleafletbottom {
     Test: assignLeaflet
 } -setup {
    mol new ../lipid_membrane/insane2.gro
-   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 1 
+   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 1 "NULL"
    set sel [atomselect top "resname POPC and z < 100"]
    set num [lsort -unique [$sel get user]]
 } -body {
@@ -215,7 +215,7 @@ test Singlelipidturned {
     Test: assignLeaflet
 } -setup {
    mol new ../lipid_membrane/fullmemsingletilt.gro
-   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 8 
+   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 8 "NULL"
    set sel [atomselect top "resname POPC and resid 1000"]
    set num [lsort -unique [$sel get user]]
 } -body {
@@ -228,7 +228,7 @@ test Singlelipidturnedminwindow {
     Test: assignLeaflet
 } -setup {
    mol new ../lipid_membrane/fullmemsingletilt.gro
-   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 2 
+   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 2 "NULL"
    set sel [atomselect top "resname POPC and resid 1000"]
    set num [lsort -unique [$sel get user]]
 } -body {

--- a/testing_materials/tcltest/unit_test.test
+++ b/testing_materials/tcltest/unit_test.test
@@ -189,7 +189,7 @@ test basicleaflettop {
     Test: assignLeaflet
 } -setup {
    mol new ../lipid_membrane/insane2.gro
-   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 1 
+   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 1 NULL 
    set sel [atomselect top "resname POPC and z > 100"]
    set num [lsort -unique [$sel get user]]
 } -body {
@@ -202,7 +202,7 @@ test basicleafletbottom {
     Test: assignLeaflet
 } -setup {
    mol new ../lipid_membrane/insane2.gro
-   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 1 
+   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 1 NULL 
    set sel [atomselect top "resname POPC and z < 100"]
    set num [lsort -unique [$sel get user]]
 } -body {
@@ -215,7 +215,7 @@ test Singlelipidturned {
     Test: assignLeaflet
 } -setup {
    mol new ../lipid_membrane/fullmemsingletilt.gro
-   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 8 
+   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 8 NULL 
    set sel [atomselect top "resname POPC and resid 1000"]
    set num [lsort -unique [$sel get user]]
 } -body {
@@ -228,7 +228,7 @@ test Singlelipidturnedminwindow {
     Test: assignLeaflet
 } -setup {
    mol new ../lipid_membrane/fullmemsingletilt.gro
-   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 2 
+   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 2 NULL 
    set sel [atomselect top "resname POPC and resid 1000"]
    set num [lsort -unique [$sel get user]]
 } -body {

--- a/testing_materials/tcltest/unit_test.test
+++ b/testing_materials/tcltest/unit_test.test
@@ -189,7 +189,7 @@ test basicleaflettop {
     Test: assignLeaflet
 } -setup {
    mol new ../lipid_membrane/insane2.gro
-   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 1 NULL 
+   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 1 
    set sel [atomselect top "resname POPC and z > 100"]
    set num [lsort -unique [$sel get user]]
 } -body {
@@ -202,7 +202,7 @@ test basicleafletbottom {
     Test: assignLeaflet
 } -setup {
    mol new ../lipid_membrane/insane2.gro
-   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 1 NULL 
+   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 1 
    set sel [atomselect top "resname POPC and z < 100"]
    set num [lsort -unique [$sel get user]]
 } -body {
@@ -215,7 +215,7 @@ test Singlelipidturned {
     Test: assignLeaflet
 } -setup {
    mol new ../lipid_membrane/fullmemsingletilt.gro
-   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 8 NULL 
+   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 8 
    set sel [atomselect top "resname POPC and resid 1000"]
    set num [lsort -unique [$sel get user]]
 } -body {
@@ -228,7 +228,7 @@ test Singlelipidturnedminwindow {
     Test: assignLeaflet
 } -setup {
    mol new ../lipid_membrane/fullmemsingletilt.gro
-   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 2 NULL 
+   assignLeaflet 0 {POPC} {{{C1A C1B}} {{C4A C4B}}} 2 
    set sel [atomselect top "resname POPC and resid 1000"]
    set num [lsort -unique [$sel get user]]
 } -body {


### PR DESCRIPTION
## Description
I wanted to run nougat on my newer systems that had free fatty acids and/or cardiolipin in them, but they errored out because analyzeTails was only designed to handle phospholipids. I have added a temporary patch that will allow nougat to run properly in the short term. In the long term, this proc will need to be redesigned (issue #387) and moved into the .py side of the codebase.

I also refactored assignLeaflet so that the variable names are a little clearer. This also needs to be redesigned at some point (potentially replacing with the membrane tools leaflet sorters) (issue #388).

## Usage Changes
None

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] analyzeTails will first check to see if the lipid is a fatty acid or cardiolipin before continuing down its original path
  - [x] assignLeaflet has been refactored for more clarity (still not perfect)
  - [x] One unit test (Multitailnumbertails) is now skipped because the .gro file associated with it has an outdated structure of cardiolipin (issue #389)

## Pre-Review checklist (PR maker)
- [x] Unit tests pass
- [x] Acceptance tests pass
- [x] Linting isn't worse than it was (linting checks pass)
- [x] Pytests pass


## Review checklist (Reviewer)
- [x] Unit tests pass
- [x] Acceptance tests pass
- [x] Linting scores haven't gotten worse (linting checks pass)
- [x] New functions/variables are named appropriately
- [x] No missed "low-hanging fruit" that would substantially aid readability.
- [x] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [x] I understand what the changes are doing and how
- [x] The PR itself is appropriately documented:
    - [x] I understand the motivation for this PR

## Status
- [x] Ready for review
