### PR TITLE
399 user cannot specify headgroups that are not part of tails

### DIFF
--- a/tcl/nougat.tcl
+++ b/tcl/nougat.tcl
@@ -192,6 +192,11 @@ proc run_nougat {system config_dict bindims polar quantity_of_interest foldernam
             $sel frame $frm 
             $sel update
 
+            ;# error check
+            if {[$sel num] == 0} {
+                error "There are no selected atoms in ${selex} on frame ${frm}"
+            }
+
             ;# assemble all data (x,y,z,user, etc) into a dict of lists
             set sel_info [getSelInfo $sel $ref_height]
 

--- a/tcl/nougat.tcl
+++ b/tcl/nougat.tcl
@@ -168,7 +168,6 @@ proc run_nougat {system config_dict bindims polar quantity_of_interest foldernam
 
         if {$polar == 0} {
             set bindims [updateDimensions $bindims $frm]
-            
         }
 
         ;# update leaflets in case lipids have flip-flopped

--- a/tcl/utilities/helper_procs.tcl
+++ b/tcl/utilities/helper_procs.tcl
@@ -1447,7 +1447,7 @@ proc readPolar {polar} {
 proc createAtomSelections {quantity configDictionary} {
     ;#atomselections setup as dict
     if {$quantity eq "height"} {
-        dict set selections z1z2 [atomselect top "resname [dict get $configDictionary species] and name [dict get $configDictionary full_tails]"]
+        dict set selections z1z2 [atomselect top "resname [dict get $configDictionary species]"]
         dict set selections z0 [atomselect top "resname [dict get $configDictionary species] and ((user 1 and within 6 of user 2) or (user 2 and within 6 of user 1))"]
     } elseif {$quantity eq "tilt_order"} {
         set lists [sortTailLength [dict get $configDictionary species] [dict get $configDictionary acyl_names]]

--- a/testing_materials/tcltest/unit_test.test
+++ b/testing_materials/tcltest/unit_test.test
@@ -730,7 +730,7 @@ test createatomselects {
     mol new ../lipid_membrane/insane2.gro
     set config_dict [cell_prep "nougat_config.txt" 1]
     set selly [createAtomSelections "height" $config_dict]
-    set sel [atomselect top "resname POPC and not name NC3 PO4 GL1 GL2"]
+    set sel [atomselect top "resname POPC"]
     set lipnum [llength [$sel get resid]]
     set cselnum [llength [[dict get $selly z1z2] get resid]]
     if {$lipnum == $cselnum} {


### PR DESCRIPTION
## Description
A previous Jesse had made atomselections for the height fields z1 and z2 unnecessarily strict. This had the side effect of making it impossible to choose a surface that contained beads that weren't in a lipid tail. IE setting the surface bead to be PO4 resulted in z1 and z2 being all nans, because PO4 beads are not "tail" beads. This has been fixed by making the atomselection simpler. To make matters worse, there was no error message when entire height fields were nan. This has been fixed too. Closes #399 and #398 .

## Usage Changes
None

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Remove tail bead names from atomselection for z1z2
  - [x] Fix unit test associated with createAtomselections to match new code
  - [x] User receives error if an entire height field is nan

## Pre-Review checklist (PR maker)
- [x] Acceptance tests pass
- [x] Linting isn't worse than it was (linting checks pass)
- [x] Pytests pass
- [x] tcltests pass
- [x] system that originally caused the discovery of this bug now runs correctly


## Review checklist (Reviewer)
- [x] Acceptance tests pass
- [x] Linting isn't worse than it was (linting checks pass)
- [x] Pytests pass
- [x] tcltests pass
- [x] No missed "low-hanging fruit" that would substantially aid readability.
- [x] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [x] I understand what the changes are doing and how
- [x] The PR itself is appropriately documented:
    - [x] I understand the motivation for this PR

## Status
- [x] Ready for review